### PR TITLE
Attempt to derive Rivian model information from VIN and add to device…

### DIFF
--- a/custom_components/rivian/binary_sensor.py
+++ b/custom_components/rivian/binary_sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_MODEL, ATTR_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -18,6 +19,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     ATTR_COORDINATOR,
     CLOSURE_STATE_ENTITIES,
+    CONF_VIN,
     DOMAIN,
     DOOR_STATE_ENTITIES,
     LOCK_STATE_ENTITIES,
@@ -138,6 +140,7 @@ class RivianAggregateBinarySensor(RivianEntity, CoordinatorEntity, BinarySensorE
         self._name = self.entity_description.key
         self._prop_key_set = prop_key_set
         self.entity_id = f"binary_sensor.{self.entity_description.key}"
+        self._vin = config_entry.data.get(CONF_VIN)
 
     @property
     def unique_id(self) -> str:
@@ -147,11 +150,29 @@ class RivianAggregateBinarySensor(RivianEntity, CoordinatorEntity, BinarySensorE
     @property
     def device_info(self) -> DeviceInfo:
         """Get device information."""
-        return {
-            "identifiers": {get_device_identifier(self._config_entry)},
-            "name": NAME,
-            "manufacturer": NAME,
-        }
+        info = DeviceInfo(
+            identifiers={get_device_identifier(self._config_entry)},
+            manufacturer=NAME,
+        )
+
+        """Attempt to derive Rivian model information from VIN."""
+        if self._vin[9] == "N":
+            model_year = "2022"
+        elif self._vin[9] == "P":
+            model_year = "2023"
+
+        if self._vin[0:5] == "7FCTG":
+            model_line = "R1T"
+        elif self._vin[0:5] == "7PDSG":
+            model_line = "R1S"
+
+        if model_year and model_line:
+            info[ATTR_MODEL] = f"{model_year} Rivian {model_line}"
+            info[ATTR_NAME] = f"Rivian {model_line}"
+        else:
+            info[ATTR_NAME] = "Rivian"
+
+        return info
 
     @property
     def is_on(self) -> bool:
@@ -186,6 +207,7 @@ class RivianBinarySensor(RivianEntity, CoordinatorEntity, BinarySensorEntity):
         self._name = self.entity_description.key
         self._prop_key = prop_key
         self.entity_id = f"binary_sensor.{self.entity_description.key}"
+        self._vin = config_entry.data.get(CONF_VIN)
 
     @property
     def unique_id(self) -> str:
@@ -195,11 +217,29 @@ class RivianBinarySensor(RivianEntity, CoordinatorEntity, BinarySensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Get device information."""
-        return {
-            "identifiers": {get_device_identifier(self._config_entry)},
-            "name": NAME,
-            "manufacturer": NAME,
-        }
+        info = DeviceInfo(
+            identifiers={get_device_identifier(self._config_entry)},
+            manufacturer=NAME,
+        )
+
+        """Attempt to derive Rivian model information from VIN."""
+        if self._vin[9] == "N":
+            model_year = "2022"
+        elif self._vin[9] == "P":
+            model_year = "2023"
+
+        if self._vin[0:5] == "7FCTG":
+            model_line = "R1T"
+        elif self._vin[0:5] == "7PDSG":
+            model_line = "R1S"
+
+        if model_year and model_line:
+            info[ATTR_MODEL] = f"{model_year} Rivian {model_line}"
+            info[ATTR_NAME] = f"Rivian {model_line}"
+        else:
+            info[ATTR_NAME] = "Rivian"
+
+        return info
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
… registry

Used information from this link to attempt to derive Rivian model line (R1T or R1S) and model year from VIN:

https://www.rivianforums.com/forum/threads/rivian-vin-decoder.1546/

Added model information, if successfully derived, to device registry